### PR TITLE
feat: install plugin updates with i from inside the picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ herdr plugin install sanirudh17/herdr-agent-handoff
 herdr plugin action invoke agent-handoff.setup-keys
 ```
 
+When a newer release exists, the picker footer says so — press `i` to install it from inside
+the picker, `u` to dismiss the notice for that version.
+
 `setup-keys` backs up your `config.toml`, adds the two keybindings, and reloads. It won't overwrite
 `prefix+a` or `prefix+shift+a` if you've already bound them — re-run with `--force`, or add them by
 hand. (`prefix+h` was avoided on purpose: it's Herdr's default `focus_pane_left`.)

--- a/bin/picker.js
+++ b/bin/picker.js
@@ -66,6 +66,42 @@ function drawHeadless(state) {
   process.stdout.write(ui.renderFrame(state).join("\n") + "\n\f");
 }
 
+// Runs the upgrade the notice advertises and folds the outcome back into
+// picker state. applyKey has already set updating:true, so the footer shows
+// the Updating line while the install blocks. Never throws: a failed upgrade
+// keeps the notice (retryable, dismissible) and the picker fully usable.
+function runInstall(state) {
+  const version =
+    state.updateNotice && state.updateNotice.version
+      ? state.updateNotice.version
+      : "unknown";
+  let result;
+  try {
+    result = updateMod.installUpdate();
+  } catch (err) {
+    result = {
+      ok: false,
+      message: (err && err.message ? err.message : String(err)).slice(0, 120),
+    };
+  }
+  trace(`install update v${version}: ${result.ok ? "ok" : result.message}`);
+  if (result.ok) {
+    return {
+      ...state,
+      updating: false,
+      updateNotice: null,
+      updateStatus: { ok: true, version },
+      settledAt: Date.now(),
+    };
+  }
+  return {
+    ...state,
+    updating: false,
+    updateStatus: { ok: false, message: result.message },
+    settledAt: Date.now(),
+  };
+}
+
 function draw(state, frame) {
   const lines = frame || ui.renderFrame(state, { styled: true });
   process.stdout.write("\x1b[H\x1b[2J" + lines.join("\r\n"));
@@ -94,6 +130,10 @@ function runHeadless(request) {
     .filter(Boolean)) {
     const out = ui.applyKey(state, key);
     state = out.state;
+    if (out.action && out.action.installUpdate) {
+      drawHeadless(state); // updating line, before the blocking install
+      state = runInstall(state);
+    }
     drawHeadless(state);
     if (out.action && out.action.select) {
       return finish(request.resultPath, { selected: out.action.select }, null);
@@ -141,6 +181,28 @@ function runInteractive(request) {
       state = out.state;
       if (out.action && out.action.dismissUpdate) {
         updateMod.dismissUpdate(out.action.dismissUpdate);
+      }
+      if (out.action && out.action.installUpdate) {
+        // Show the Updating line first: stdout to a terminal flushes on
+        // write, so the user sees it before the blocking install starts.
+        draw(state);
+        state = runInstall(state);
+        draw(state);
+        continue;
+      }
+      // Keys hammered while the install blocked arrive as one buffered burst
+      // the moment input flows again. A select/cancel among them was aimed
+      // at the install, not the picker — drop it rather than handing off or
+      // blinking out from under the user.
+      if (
+        state.settledAt &&
+        Date.now() - state.settledAt < 500 &&
+        out.action &&
+        (out.action.select || out.action.cancel)
+      ) {
+        state = { ...state, settledAt: 0 };
+        draw(state);
+        continue;
       }
       if (out.action && out.action.select) {
         // Show the choice before the popup disappears, so the selection is

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "agent-handoff"
 name = "Agent Handoff"
-version = "0.1.2"
+version = "0.2.0"
 min_herdr_version = "0.7.5"
 description = "Transfer an in-progress session to a fresh session of another installed agent"
 platforms = ["linux", "macos", "windows"]

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -110,6 +110,8 @@ function initialState(opts) {
     height = 20,
     theme = null,
     updateNotice = opts.updateNotice || null,
+    updating = false,
+    updateStatus = null,
   } = opts;
   return {
     contextLine,
@@ -118,6 +120,11 @@ function initialState(opts) {
     notInstalled,
     theme,
     updateNotice,
+    // updating tracks an in-flight `i` install so a second press cannot
+    // stack another one; updateStatus carries the last outcome for the
+    // footer after the install settles.
+    updating,
+    updateStatus,
     section: "installed",
     cursor: 0,
     // The not-installed list gets its own indicator: browsing it with no marker at
@@ -213,6 +220,17 @@ function applyKey(state, key) {
     return {
       state: { ...state, updateNotice: null },
       action: { dismissUpdate: version },
+    };
+  }
+
+  // Install the update the notice advertises, inside the picker. Only while
+  // a notice is showing and no install is already running; anything else is
+  // inert so the key never disturbs normal browsing.
+  if ((key === "i" || key === "I") && state.updateNotice && !state.updating) {
+    const version = state.updateNotice.version;
+    return {
+      state: { ...state, updating: true, updateStatus: null },
+      action: { installUpdate: version },
     };
   }
 
@@ -462,20 +480,62 @@ function headerLine(state, width, styled, total) {
 }
 
 function footerLine(state, width, styled) {
+  const t = tokens(state);
+  if (state.updating && state.updateNotice) {
+    return style(
+      truncate(`  Updating to v${state.updateNotice.version}…`, width),
+      t.accentText,
+      styled,
+    );
+  }
+  if (state.updateStatus) {
+    const s = state.updateStatus;
+    const text = s.ok
+      ? `  ✓ Updated to v${s.version} — takes effect on next handoff`
+      : `  ✗ Update failed: ${s.message}`;
+    return style(truncate(text, width), t.accentText, styled);
+  }
   if (state.updateNotice && state.updateNotice.available) {
     const v = state.updateNotice.version;
     const notice = `  Update available (v${v}): herdr plugin install sanirudh17/herdr-agent-handoff`;
+    const installChip = " i install ";
     const dismissChip = " u dismiss ";
-    const t = tokens(state);
-    if (notice.length + dismissChip.length + 1 <= width) {
-      const gap = Math.max(1, width - notice.length - dismissChip.length);
+    if (notice.length + installChip.length + dismissChip.length + 2 <= width) {
+      const gap = Math.max(
+        1,
+        width - notice.length - installChip.length - 1 - dismissChip.length,
+      );
       return (
         style(notice, t.accentText, styled) +
         " ".repeat(gap) +
-        style(dismissChip, t.primaryChip, styled)
+        style(installChip, t.primaryChip, styled) +
+        " " +
+        style(dismissChip, t.secondaryChip, styled)
       );
     }
     const shortNotice = `  Update v${v} available`;
+    if (
+      shortNotice.length + installChip.length + dismissChip.length + 2 <=
+      width
+    ) {
+      const gap = Math.max(
+        1,
+        width -
+          shortNotice.length -
+          installChip.length -
+          1 -
+          dismissChip.length,
+      );
+      return (
+        style(shortNotice, t.accentText, styled) +
+        " ".repeat(gap) +
+        style(installChip, t.primaryChip, styled) +
+        " " +
+        style(dismissChip, t.secondaryChip, styled)
+      );
+    }
+    // Narrow panes keep the dismiss chip they have always had; `i` still
+    // installs, and the README documents it.
     if (shortNotice.length + dismissChip.length + 1 <= width) {
       const gap = Math.max(1, width - shortNotice.length - dismissChip.length);
       return (
@@ -506,7 +566,6 @@ function footerLine(state, width, styled) {
     { label: " esc ", primary: false },
   ];
 
-  const t = tokens(state);
   const render = (list) =>
     list
       .map((c) =>

--- a/lib/update.js
+++ b/lib/update.js
@@ -3,12 +3,18 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const https = require("node:https");
+const { spawnSync } = require("node:child_process");
 const { stateDir } = require("./paths.js");
 
-const CURRENT_VERSION = "0.1.2";
+const CURRENT_VERSION = "0.2.0";
 const REPO_OWNER = "sanirudh17";
 const REPO_NAME = "herdr-agent-handoff";
+const INSTALL_SPEC = `${REPO_OWNER}/${REPO_NAME}`;
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+// Reinstalling means refetching the plugin from GitHub; even a small repo can
+// stall on a slow network, but the picker is blocked while this runs, so cap
+// it rather than hanging the handoff behind it.
+const INSTALL_TIMEOUT_MS = 120000;
 
 function cacheFile(env = process.env) {
   const dir = stateDir(env);
@@ -139,6 +145,8 @@ function checkUpdateAsync(env = process.env) {
 
 module.exports = {
   CURRENT_VERSION,
+  INSTALL_SPEC,
+  INSTALL_TIMEOUT_MS,
   isNewer,
   parseVersion,
   readCache,
@@ -146,4 +154,71 @@ module.exports = {
   dismissUpdate,
   checkUpdateAsync,
   triggerProbe,
+  installCommand,
+  installUpdate,
 };
+
+// The exact command the footer has always told users to run by hand.
+// UPDATE_FAKE_INSTALL is the single test seam: a script run via node in place
+// of `herdr plugin install …`. It is never set in production.
+function installCommand(env = process.env) {
+  if (env.UPDATE_FAKE_INSTALL) {
+    return {
+      bin: process.execPath,
+      args: [env.UPDATE_FAKE_INSTALL, "plugin", "install", "-y", INSTALL_SPEC],
+    };
+  }
+  return {
+    bin: env.HERDR_BIN_PATH || "herdr",
+    args: ["plugin", "install", "-y", INSTALL_SPEC],
+  };
+}
+
+function installTimeoutMs(env = process.env) {
+  const value = Number(env.UPDATE_INSTALL_TIMEOUT_MS);
+  return Number.isFinite(value) && value > 0 ? value : INSTALL_TIMEOUT_MS;
+}
+
+// Runs the upgrade the notice advertises and reports the outcome for the
+// footer. Never throws: a failed upgrade must leave the picker usable, with
+// the notice still in place so the user can retry or dismiss it.
+function installUpdate(env = process.env) {
+  const { bin, args } = installCommand(env);
+  let res;
+  try {
+    res = spawnSync(bin, args, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      env,
+      timeout: installTimeoutMs(env),
+    });
+  } catch (err) {
+    return { ok: false, message: describeInstallError(err, env) };
+  }
+  if (res.error)
+    return { ok: false, message: describeInstallError(res.error, env) };
+  if (res.status !== 0) {
+    return { ok: false, message: lastLine(res.stderr || res.stdout) };
+  }
+  return { ok: true };
+}
+
+function describeInstallError(err, env = process.env) {
+  const message = (err && err.message ? err.message : String(err)).trim();
+  if (/ETIMEDOUT|timed out/i.test(message)) {
+    return `install timed out after ${Math.round(installTimeoutMs(env) / 1000)}s`;
+  }
+  if (/ENOENT/i.test(message)) {
+    return "herdr executable not found on PATH";
+  }
+  return lastLine(message);
+}
+
+function lastLine(text) {
+  const lines = String(text || "")
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter(Boolean);
+  const line = lines.length > 0 ? lines[lines.length - 1] : "install failed";
+  return line.length > 120 ? `${line.slice(0, 119)}…` : line;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "herdr-agent-handoff",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "herdr-agent-handoff",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "herdr-agent-handoff",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Full-session ownership transfer between Herdr-supported coding agents",
   "license": "MIT",
   "author": "Anirudh S K",

--- a/test/fixtures/fake-herdr-install.js
+++ b/test/fixtures/fake-herdr-install.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+"use strict";
+
+// Test stand-in for `herdr plugin install …`. Controlled by environment so the
+// update-install path is exercisable on every platform without touching a real
+// Herdr setup (which, on a dev machine, would replace a linked plugin with a
+// marketplace copy):
+//   FAKE_HERDR_INSTALL_FAIL=1  -> exit 1 with an error on stderr
+//   FAKE_HERDR_INSTALL_HANG=1  -> never exit (exercises the install timeout)
+// otherwise                         -> exit 0 with a line on stdout
+if (process.env.FAKE_HERDR_INSTALL_HANG === "1") {
+  setInterval(() => {}, 1000);
+} else if (process.env.FAKE_HERDR_INSTALL_FAIL === "1") {
+  process.stderr.write(
+    "herdr plugin install failed: simulated failure for tests\n",
+  );
+  process.exit(1);
+} else {
+  process.stdout.write(
+    `installed ${process.argv.slice(2).join(" ") || "(no args)"}\n`,
+  );
+  process.exit(0);
+}

--- a/test/picker.test.js
+++ b/test/picker.test.js
@@ -31,7 +31,7 @@ function setup() {
   return { dir, requestPath, resultPath };
 }
 
-function runPicker(requestPath, keys) {
+function runPicker(requestPath, keys, extraEnv = {}) {
   return spawnSync(process.execPath, [PICKER], {
     input: keys.join("\n") + "\n",
     encoding: "utf8",
@@ -39,9 +39,53 @@ function runPicker(requestPath, keys) {
       ...process.env,
       HERDR_HANDOFF_REQUEST: requestPath,
       HANDOFF_PICKER_HEADLESS: "1",
+      ...extraEnv,
     },
   });
 }
+
+// Seeds an update notice by pre-writing a fresh cache, so the headless picker
+// shows one without any network. Returns env overrides for runPicker.
+function updateEnv(latestVersion) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "handoff-pick-upd-"));
+  fs.writeFileSync(
+    path.join(dir, "update-cache.json"),
+    JSON.stringify({ lastCheckUnix: Date.now(), latestVersion }),
+  );
+  return {
+    HERDR_PLUGIN_STATE_DIR: dir,
+    UPDATE_FAKE_INSTALL: path.join(
+      __dirname,
+      "fixtures",
+      "fake-herdr-install.js",
+    ),
+  };
+}
+
+test("i installs the update and reports success in the picker", () => {
+  const { requestPath, resultPath } = setup();
+  const res = runPicker(requestPath, ["i"], updateEnv("9.9.9"));
+  assert.equal(res.status, 0, res.stderr);
+  assert.match(res.stdout, /Updating to v9\.9\.9/, "updating line shown");
+  assert.match(res.stdout, /✓ Updated to v9\.9\.9/, "success reported");
+  assert.deepEqual(JSON.parse(fs.readFileSync(resultPath, "utf8")), {
+    cancelled: true,
+  });
+});
+
+test("a failed install keeps the picker usable and says why", () => {
+  const { requestPath, resultPath } = setup();
+  const res = runPicker(requestPath, ["i"], {
+    ...updateEnv("9.9.9"),
+    FAKE_HERDR_INSTALL_FAIL: "1",
+  });
+  assert.equal(res.status, 0, res.stderr);
+  assert.match(res.stdout, /✗ Update failed/, "failure reported");
+  assert.match(res.stdout, /Update v9\.9\.9 available/, "notice retained");
+  assert.deepEqual(JSON.parse(fs.readFileSync(resultPath, "utf8")), {
+    cancelled: true,
+  });
+});
 
 test("selecting with enter writes the chosen kind", () => {
   const { requestPath, resultPath } = setup();

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -635,3 +635,95 @@ test("dismissing update restores normal footer in next render", () => {
   assert.ok(!text.includes("Update"), "notice gone after dismiss");
   assert.match(text, /↑↓ select/, "normal hints restored");
 });
+
+// --- one-key install (`i`) ---------------------------------------------------
+
+test("i key starts an install while a notice is showing", () => {
+  const s = state({ updateNotice: { available: true, version: "0.2.0" } });
+  const out = ui.applyKey(s, "i");
+  assert.equal(out.state.updating, true, "install marked in flight");
+  assert.deepEqual(out.action, { installUpdate: "0.2.0" });
+});
+
+test("I key starts an install like lowercase i", () => {
+  const s = state({ updateNotice: { available: true, version: "0.2.0" } });
+  const out = ui.applyKey(s, "I");
+  assert.deepEqual(out.action, { installUpdate: "0.2.0" });
+});
+
+test("i key does nothing without a notice or while installing", () => {
+  assert.equal(ui.applyKey(state(), "i").action, null, "no notice");
+  const busy = state({
+    updateNotice: { available: true, version: "0.2.0" },
+    updating: true,
+  });
+  const out = ui.applyKey(busy, "i");
+  assert.equal(out.action, null, "no second install while one runs");
+  assert.equal(out.state.updating, true);
+});
+
+test("notice footer offers install and dismiss when they fit", () => {
+  const s = state({
+    width: 120,
+    updateNotice: { available: true, version: "0.2.0" },
+  });
+  const footer = ui.renderFrame(s).pop();
+  assert.match(footer, /Update available.*v0\.2\.0/);
+  assert.match(footer, /i install/);
+  assert.match(footer, /u dismiss/);
+});
+
+test("short notice footer offers both chips at medium widths", () => {
+  const s = state({
+    width: 60,
+    updateNotice: { available: true, version: "0.2.0" },
+  });
+  const footer = ui.renderFrame(s).pop();
+  assert.match(footer, /Update v0\.2\.0 available/);
+  assert.match(footer, /i install/);
+  assert.match(footer, /u dismiss/);
+  assert.ok(footer.length <= 60, `footer must fit: ${footer.length} chars`);
+});
+
+test("narrow notice footer keeps dismiss; i still works", () => {
+  const notice = { available: true, version: "0.2.0" };
+  const s = state({ width: 40, updateNotice: notice });
+  const footer = ui.renderFrame(s).pop();
+  assert.match(footer, /u dismiss/);
+  assert.ok(footer.length <= 40, `footer must fit: ${footer.length} chars`);
+  assert.deepEqual(ui.applyKey(s, "i").action, { installUpdate: "0.2.0" });
+});
+
+test("updating footer names the version being installed", () => {
+  const s = state({
+    updateNotice: { available: true, version: "0.2.0" },
+    updating: true,
+  });
+  assert.match(plain(s), /Updating to v0\.2\.0/);
+});
+
+test("install outcome footer reports success and failure", () => {
+  const ok = plain(state({ updateStatus: { ok: true, version: "0.2.0" } }));
+  assert.match(ok, /✓ Updated to v0\.2\.0/);
+  const bad = plain(state({ updateStatus: { ok: false, message: "boom" } }));
+  assert.match(bad, /✗ Update failed: boom/);
+});
+
+test("install footer states never wrap at any width", () => {
+  const variants = [
+    { updateNotice: { available: true, version: "0.2.0" }, updating: true },
+    { updateStatus: { ok: true, version: "0.2.0" } },
+    { updateStatus: { ok: false, message: "some long failure reason" } },
+  ];
+  for (const v of variants) {
+    for (const width of [24, 34, 40, 56, 78, 120]) {
+      const frame = ui.renderFrame(state({ width, ...v }));
+      for (const line of frame) {
+        assert.ok(
+          line.length <= Math.max(24, width),
+          `width ${width}: line of ${line.length} chars would wrap`,
+        );
+      }
+    }
+  }
+});

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -20,6 +20,13 @@ function tmpEnv() {
   return { HERDR_PLUGIN_STATE_DIR: dir, dir };
 }
 
+// A version guaranteed newer than CURRENT_VERSION, so these tests survive
+// future bumps (a hardcoded "next" version silently becomes current).
+function newer(bump = 1) {
+  const p = parseVersion(CURRENT_VERSION);
+  return `${p.major}.${p.minor}.${p.patch + bump}`;
+}
+
 test("parseVersion extracts semver correctly", () => {
   assert.deepEqual(parseVersion("0.1.0"), {
     major: 0,
@@ -72,12 +79,13 @@ test("dismissUpdate updates dismissedVersion in cache", () => {
 test("checkUpdateAsync returns available when cached version is newer and not dismissed", () => {
   const { HERDR_PLUGIN_STATE_DIR, dir } = tmpEnv();
   const env = { HERDR_PLUGIN_STATE_DIR };
+  const next = newer();
 
-  writeCache({ lastCheckUnix: Date.now(), latestVersion: "0.2.0" }, env);
+  writeCache({ lastCheckUnix: Date.now(), latestVersion: next }, env);
   const res = checkUpdateAsync(env);
-  assert.deepEqual(res, { available: true, version: "0.2.0" });
+  assert.deepEqual(res, { available: true, version: next });
 
-  dismissUpdate("0.2.0", env);
+  dismissUpdate(next, env);
   const resAfterDismiss = checkUpdateAsync(env);
   assert.deepEqual(resAfterDismiss, { available: false });
 
@@ -89,12 +97,12 @@ test("stale cache triggers a background probe but returns cached result", () => 
   const env = { HERDR_PLUGIN_STATE_DIR };
   // Cache is 48 hours old — stale.
   writeCache(
-    { lastCheckUnix: Date.now() - 48 * 60 * 60 * 1000, latestVersion: "0.2.0" },
+    { lastCheckUnix: Date.now() - 48 * 60 * 60 * 1000, latestVersion: newer() },
     env,
   );
   const res = checkUpdateAsync(env);
   // Should still return the cached result while the probe runs in background.
-  assert.deepEqual(res, { available: true, version: "0.2.0" });
+  assert.deepEqual(res, { available: true, version: newer() });
   fs.rmSync(dir, { recursive: true, force: true });
 });
 
@@ -123,14 +131,14 @@ test("dismissing one version does not suppress a newer version", () => {
   const { HERDR_PLUGIN_STATE_DIR, dir } = tmpEnv();
   const env = { HERDR_PLUGIN_STATE_DIR };
 
-  writeCache({ lastCheckUnix: Date.now(), latestVersion: "0.2.0" }, env);
-  dismissUpdate("0.2.0", env);
+  writeCache({ lastCheckUnix: Date.now(), latestVersion: newer() }, env);
+  dismissUpdate(newer(), env);
   assert.deepEqual(checkUpdateAsync(env), { available: false });
 
   // Simulate a new release appearing.
-  writeCache({ lastCheckUnix: Date.now(), latestVersion: "0.3.0" }, env);
+  writeCache({ lastCheckUnix: Date.now(), latestVersion: newer(2) }, env);
   const res = checkUpdateAsync(env);
-  assert.deepEqual(res, { available: true, version: "0.3.0" });
+  assert.deepEqual(res, { available: true, version: newer(2) });
 
   fs.rmSync(dir, { recursive: true, force: true });
 });
@@ -163,4 +171,64 @@ test("package.json, herdr-plugin.toml and CURRENT_VERSION agree", () => {
   assert.ok(manifestVersion, "herdr-plugin.toml must declare a version");
   assert.equal(CURRENT_VERSION, pkg.version);
   assert.equal(CURRENT_VERSION, manifestVersion);
+});
+
+// --- one-key install (the picker's `i` action) ------------------------------
+
+const INSTALL_FIXTURE = path.join(
+  __dirname,
+  "fixtures",
+  "fake-herdr-install.js",
+);
+
+test("installCommand runs the documented upgrade command", () => {
+  const { installCommand, INSTALL_SPEC } = require("../lib/update.js");
+  assert.deepEqual(installCommand({}), {
+    bin: "herdr",
+    args: ["plugin", "install", "-y", INSTALL_SPEC],
+  });
+  assert.equal(INSTALL_SPEC, "sanirudh17/herdr-agent-handoff");
+});
+
+test("installCommand honours HERDR_BIN_PATH like the rest of the plugin", () => {
+  const { installCommand } = require("../lib/update.js");
+  const cmd = installCommand({ HERDR_BIN_PATH: "/opt/herdr" });
+  assert.equal(cmd.bin, "/opt/herdr");
+  assert.deepEqual(cmd.args.slice(0, 2), ["plugin", "install"]);
+});
+
+test("installUpdate reports success when herdr exits zero", () => {
+  const { installUpdate } = require("../lib/update.js");
+  const res = installUpdate({ UPDATE_FAKE_INSTALL: INSTALL_FIXTURE });
+  assert.deepEqual(res, { ok: true });
+});
+
+test("installUpdate reports the failure reason without throwing", () => {
+  const { installUpdate } = require("../lib/update.js");
+  const res = installUpdate({
+    UPDATE_FAKE_INSTALL: INSTALL_FIXTURE,
+    FAKE_HERDR_INSTALL_FAIL: "1",
+  });
+  assert.equal(res.ok, false);
+  assert.match(res.message, /simulated failure/);
+});
+
+test("installUpdate gives up after the timeout instead of hanging", () => {
+  const { installUpdate } = require("../lib/update.js");
+  const res = installUpdate({
+    UPDATE_FAKE_INSTALL: INSTALL_FIXTURE,
+    FAKE_HERDR_INSTALL_HANG: "1",
+    UPDATE_INSTALL_TIMEOUT_MS: "500",
+  });
+  assert.equal(res.ok, false);
+  assert.match(res.message, /timed out/);
+});
+
+test("installUpdate reports a missing herdr binary readably", () => {
+  const { installUpdate } = require("../lib/update.js");
+  const res = installUpdate({
+    HERDR_BIN_PATH: path.join(os.tmpdir(), "no-such-herdr-binary"),
+  });
+  assert.equal(res.ok, false);
+  assert.match(res.message, /not found on PATH/);
 });


### PR DESCRIPTION
Pressing `i` while the update notice shows runs the documented upgrade (`herdr plugin install -y …`) and reports the outcome in the footer — success clears the notice, failure keeps it for retry with the reason shown. Buffered keys landing right after the install settles can't misfire a handoff. Narrow panes keep the dismiss chip; `i` still works there.

Bumps to 0.2.0 (all four version sources + consistency test). After merge: tag `v0.2.0` and publish the release so the updater offers it.